### PR TITLE
Fix length parameter in send_feature_report

### DIFF
--- a/hidapi.py
+++ b/hidapi.py
@@ -283,7 +283,7 @@ class Device(object):
         buf = ffi.buffer(bufp, len(data)+1)
         buf[0] = report_id
         buf[1:] = data
-        rv = hidapi.hid_send_feature_report(self._device, bufp, len(data))
+        rv = hidapi.hid_send_feature_report(self._device, bufp, len(bufp))
         if rv == -1:
             raise IOError("Failed to send feature report to HID device: {0}"
                           .format(self._get_last_error_string()))


### PR DESCRIPTION
The length sent to hid_send_feature_report should always be the number of bytes in the buffer. send_feature_report is currently only sending the number of bytes after the report_id. From the hidapi documentation:

"Since the Report ID is mandatory, calls to hid_send_feature_report() will always contain one more byte than the report contains. For example, if a hid report is 16 bytes long, 17 bytes must be passed to hid_send_feature_report(): the Report ID (or 0x0, for devices which do not use numbered reports), followed by the report data (16 bytes). In this example, the length passed in would be 17."